### PR TITLE
Add DELETE endpoint for a specific record in UCSBDiningCommonsMenuItem table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -32,7 +32,7 @@ import java.time.LocalDateTime;
 @RequestMapping("/api/ucsbdiningcommonsmenuitem")
 @RestController
 @Slf4j
-public class UCSBDiningCommonsMenuItemController {
+public class UCSBDiningCommonsMenuItemController extends ApiController{
     
     @Autowired
     UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
@@ -64,5 +64,17 @@ public class UCSBDiningCommonsMenuItemController {
         UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
 
         return savedUcsbDiningCommonsMenuItem;
+    }
+
+    @Operation(summary= "Get a single dining commons menu item by id")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name="id") @RequestParam Long id) {
+                
+        UCSBDiningCommonsMenuItem menuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return menuItem;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -77,4 +77,23 @@ public class UCSBDiningCommonsMenuItemController extends ApiController{
 
         return menuItem;
     }
+
+    @Operation(summary= "Update a single dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateUCSBDate(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+        UCSBDiningCommonsMenuItem menuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        menuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        menuItem.setName(incoming.getName());
+        menuItem.setStation(incoming.getStation());
+
+        ucsbDiningCommonsMenuItemRepository.save(menuItem);
+
+        return menuItem;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -81,7 +81,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController{
     @Operation(summary= "Update a single dining commons menu item")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")
-    public UCSBDiningCommonsMenuItem updateUCSBDate(
+    public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
             @Parameter(name="id") @RequestParam Long id,
             @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
 
@@ -95,5 +95,17 @@ public class UCSBDiningCommonsMenuItemController extends ApiController{
         ucsbDiningCommonsMenuItemRepository.save(menuItem);
 
         return menuItem;
+    }
+
+    @Operation(summary= "Delete a single dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id) {
+                UCSBDiningCommonsMenuItem menuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+                ucsbDiningCommonsMenuItemRepository.delete(menuItem);
+        return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,68 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name="UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController {
+    
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @Operation(summary= "List all ucsb dining commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDates() {
+        Iterable<UCSBDiningCommonsMenuItem> menuItems = ucsbDiningCommonsMenuItemRepository.findAll();
+        return menuItems;
+    }
+
+    @Operation(summary= "Create a new dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUcsbDiningCommonsMenuItem(
+            @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name="name") @RequestParam String name,
+            @Parameter(name="station") @RequestParam String station)
+            throws JsonProcessingException {
+
+        log.info("diningCommonsCode={}, name={}, station={}", diningCommonsCode, name, station);
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+        ucsbDiningCommonsMenuItem.setName(name);;
+        ucsbDiningCommonsMenuItem.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return savedUcsbDiningCommonsMenuItem;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    
+    private String diningCommonsCode;
+    private String name;
+    private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+    
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItem-1",
+          "author": "CappillenL",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEM"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_13"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEM"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository; 
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
@@ -21,7 +21,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
-import java.lang.reflect.Array;
 import java.time.LocalDateTime;
 
 import java.util.Optional;
@@ -35,8 +34,8 @@ import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
 @Import(TestConfig.class)
-public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase{
-    
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
     @MockBean
     UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
 
@@ -44,31 +43,31 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     UserRepository userRepository;
 
     // Tests for GET /api/ucsbdiningcommonsmenuitem/all
-        
+
     @Test
     public void logged_out_users_cannot_get_all() throws Exception {
-            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
-                            .andExpect(status().is(403)); // logged out users can't get all
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void logged_in_users_can_get_all() throws Exception {
-            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
-                            .andExpect(status().is(200)); // logged
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                .andExpect(status().is(200)); // logged
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
         UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
-                                            .diningCommonsCode("I2LD")
-                                            .name("PIZZA")
-                                            .station("Taco Station").build();
+                .diningCommonsCode("I2LD")
+                .name("PIZZA")
+                .station("Taco Station").build();
         UCSBDiningCommonsMenuItem item2 = UCSBDiningCommonsMenuItem.builder()
-                                            .diningCommonsCode("PO2K")
-                                            .name("TACO")
-                                            .station("Soup Station").build();
+                .diningCommonsCode("PO2K")
+                .name("TACO")
+                .station("Soup Station").build();
 
         ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
         expectedItems.addAll(Arrays.asList(item1, item2));
@@ -77,53 +76,106 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
         // act
         MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
-                            .andExpect(status().isOk()).andReturn();
+                .andExpect(status().isOk()).andReturn();
 
         // assert
 
         verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
         String expectedJson = mapper.writeValueAsString(expectedItems);
         String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString); 
+        assertEquals(expectedJson, responseString);
     }
 
     // Tests for POST /api/ucsbdiningcommonsmenuitem/post...
 
     @Test
     public void logged_out_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
-                            .andExpect(status().is(403));
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                .andExpect(status().is(403));
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void logged_in_regular_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
-                            .andExpect(status().is(403)); // only admins can post
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                .andExpect(status().is(403)); // only admins can post
     }
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void an_admin_user_can_post_a_new_ucsbdiningcommonsmenuitem() throws Exception {
-            // arrange
+        // arrange
 
-            UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
-                                                .diningCommonsCode("I2LD")
-                                                .name("PIZZA")
-                                                .station("Taco Station").build();
+        UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("I2LD")
+                .name("PIZZA")
+                .station("Taco Station").build();
 
-            when(ucsbDiningCommonsMenuItemRepository.save(eq(item1))).thenReturn(item1);
+        when(ucsbDiningCommonsMenuItemRepository.save(eq(item1))).thenReturn(item1);
 
-            // act
-            MvcResult response = mockMvc.perform(
-                            post("/api/ucsbdiningcommonsmenuitem/post?diningCommonsCode=I2LD&name=PIZZA&station=Taco Station")
-                                            .with(csrf()))
-                            .andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/ucsbdiningcommonsmenuitem/post?diningCommonsCode=I2LD&name=PIZZA&station=Taco Station")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
-            // assert
-            verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(item1);
-            String expectedJson = mapper.writeValueAsString(item1);
-            String responseString = response.getResponse().getContentAsString();
-            assertEquals(expectedJson, responseString);
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(item1);
+        String expectedJson = mapper.writeValueAsString(item1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for GET /api/ucsbdiningcommonsmenuitem?id=...
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+                .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+        // arrange
+
+        UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("I2LD")
+                .name("PIZZA")
+                .station("Taco Station").build();
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(item1));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(item1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+                        .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,129 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.lang.reflect.Array;
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase{
+    
+    @MockBean
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/ucsbdiningcommonsmenuitem/all
+        
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
+        UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+                                            .diningCommonsCode("I2LD")
+                                            .name("PIZZA")
+                                            .station("Taco Station").build();
+        UCSBDiningCommonsMenuItem item2 = UCSBDiningCommonsMenuItem.builder()
+                                            .diningCommonsCode("PO2K")
+                                            .name("TACO")
+                                            .station("Soup Station").build();
+
+        ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
+        expectedItems.addAll(Arrays.asList(item1, item2));
+
+        when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedItems);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString); 
+    }
+
+    // Tests for POST /api/ucsbdiningcommonsmenuitem/post...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsbdiningcommonsmenuitem() throws Exception {
+            // arrange
+
+            UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+                                                .diningCommonsCode("I2LD")
+                                                .name("PIZZA")
+                                                .station("Taco Station").build();
+
+            when(ucsbDiningCommonsMenuItemRepository.save(eq(item1))).thenReturn(item1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/ucsbdiningcommonsmenuitem/post?diningCommonsCode=I2LD&name=PIZZA&station=Taco Station")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(item1);
+            String expectedJson = mapper.writeValueAsString(item1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -184,7 +184,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
-    public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+    public void admin_can_edit_an_existing_ucsbdiningcommonsmenuitem() throws Exception {
         // arrange
 
         UCSBDiningCommonsMenuItem itemOrig = UCSBDiningCommonsMenuItem.builder()
@@ -219,7 +219,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
-    public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+    public void admin_cannot_edit_ucsbdiningcommonsmenuitem_that_does_not_exist() throws Exception {
         // arrange
 
         UCSBDiningCommonsMenuItem itemEdited = UCSBDiningCommonsMenuItem.builder()
@@ -244,5 +244,53 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         Map<String, Object> json = responseToJson(response);
         assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
 
+    }
+
+    // Tests for DELETE /api/ucsbdiningcommonsmenuitem?id=...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_ucsbdiningcommonsmenuitem() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem menuItem = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("I2LD")
+                .name("PIZZA")
+                .station("Pizza Station").build();
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(menuItem));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/ucsbdiningcommonsmenuitem?id=15")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_ucsbdiningcommonsmenuitem_and_gets_right_error_message()
+            throws Exception {
+        // arrange
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/ucsbdiningcommonsmenuitem?id=15")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -190,7 +190,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         UCSBDiningCommonsMenuItem itemOrig = UCSBDiningCommonsMenuItem.builder()
                 .diningCommonsCode("I2LD")
                 .name("PIZZA")
-                .station("Taco Station").build();
+                .station("Pizza Station").build();
 
         UCSBDiningCommonsMenuItem itemEdited = UCSBDiningCommonsMenuItem.builder()
                 .diningCommonsCode("DLG")


### PR DESCRIPTION
Modified UCSBDiningCommonsMenuItem Controller with a HTTP DELETE endpoint at `/api/ucsbdiningcommonsmenuitem/`. This endpoint will delete a menu item with `id`. And return a message if the deletion was successful

Dev deployment can be viewed at: https://team02-calee14-dev.dokku-15.cs.ucsb.edu/swagger-ui/index.html#/UCSBDiningCommonsMenuItem

Closes #12 